### PR TITLE
Easier leveling

### DIFF
--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -202,6 +202,21 @@ const unscaledLeveling: Task[] = [
     limit: { tries: 5 },
   },
   {
+    name: "God Lobster",
+    completed: () => get("_godLobsterFights") >= 3 || !have($familiar`God Lobster`),
+    do: () => visitUrl("main.php?fightgodlobster=1"),
+    combat: new CombatStrategy().killHard(),
+    choices: { 1310: have($item`God Lobster's Ring`) ? 2 : 3 }, // Get xp on last fight
+    outfit: {
+      famequip: $items`God Lobster's Ring, God Lobster's Scepter`,
+      familiar: $familiar`God Lobster`,
+    },
+    limit: { tries: 3 },
+    post: (): void => {
+      useFamiliar($familiar`Grey Goose`)
+    },
+  },
+  {
     name: "Snojo",
     after: getBuffs,
     priority: () => Priorities.Start,

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -2,6 +2,7 @@ import { CombatStrategy } from "../engine/combat";
 import {
   cliExecute,
   Item,
+  monkeyPaw,
   myLevel,
   myPrimestat,
   myTurncount,
@@ -39,6 +40,14 @@ const robotSetup = [
   "Robot/Equip Top Initial",
   "Robot/Equip Right Initial",
 ];
+
+function bestWishes(): [boolean, string | undefined] {
+  const genie = have($item`pocket wish`) || (have($item`genie bottle`) && get("_genieWishesUsed") < 3);
+  const paw = have($item`cursed monkey's paw`) && get("_monkeyPawWishesUsed", 0) < 5;
+  const bestWishes = paw ? "paw" : genie ? "genie" : undefined;
+
+  return [!(genie || paw), bestWishes]
+}
 
 const buffTasks: Task[] = [
   {
@@ -79,10 +88,14 @@ const buffTasks: Task[] = [
     after: robotSetup,
     completed: () =>
       have($effect`Warm Shoulders`) ||
-      (!have($item`pocket wish`) && (!have($item`genie bottle`) || get("_genieWishesUsed") >= 3)) ||
+      bestWishes()[0] ||
       myTurncount() >= 20,
     priority: () => Priorities.Free,
-    do: () => cliExecute("genie effect warm shoulders"),
+    do: (): void => {
+      if(bestWishes()[1] === "genie")
+        cliExecute("genie effect warm shoulders");
+      else monkeyPaw($effect`Warm Shoulders`);
+      },
     freeaction: true,
     limit: { tries: 1 },
   },
@@ -91,10 +104,14 @@ const buffTasks: Task[] = [
     after: robotSetup,
     completed: () =>
       have($effect`Blue Swayed`) ||
-      (!have($item`pocket wish`) && (!have($item`genie bottle`) || get("_genieWishesUsed") >= 3)) ||
+      bestWishes()[0]  ||
       myTurncount() >= 20,
     priority: () => Priorities.Free,
-    do: () => cliExecute("genie effect blue swayed"),
+    do: (): void => {
+      if(bestWishes()[1] === "genie")
+        cliExecute("genie effect blue swayed");
+      else monkeyPaw($effect`Blue Swayed`)
+    },
     freeaction: true,
     limit: { tries: 1 },
   },
@@ -127,7 +144,7 @@ const unscaledLeveling: Task[] = [
     completed: () => get("_mayamSymbolsUsed").includes("fur"),
     do: (): void => {
       useFamiliar($familiar`Grey Goose`);
-      cliExecute("Mayam fur wood cheese clock")
+      cliExecute("Mayam rings fur wood cheese clock")
     },
     limit: { tries: 1 },
     freeaction: true,

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -25,7 +25,6 @@ import {
   get,
   have,
   Macro,
-  MayamCalendar,
   set,
 } from "libram";
 import { Priorities } from "../engine/priority";
@@ -137,19 +136,6 @@ const unscaledLeveling: Task[] = [
     freeaction: true,
   },
   {
-    name: "Mayam: Boost a Gooso",
-    after: getBuffs,
-    priority: () => Priorities.Free,
-    ready: () => MayamCalendar.have(),
-    completed: () => get("_mayamSymbolsUsed").includes("fur"),
-    do: (): void => {
-      useFamiliar($familiar`Grey Goose`);
-      cliExecute("Mayam rings fur wood cheese clock")
-    },
-    limit: { tries: 1 },
-    freeaction: true,
-  },
-  {
     name: "LOV Tunnel",
     after: getBuffsPreLOV,
     priority: () => Priorities.Free,
@@ -205,18 +191,6 @@ const unscaledLeveling: Task[] = [
     outfit: {
       modifier: "exp",
     },
-  },
-  {
-    name: "Burning Leaves",
-    after: getBuffs,
-    ready: () => !have($effect`Shadow Affinity`),
-    completed: () => get("_leafMonstersFought", 0) >= 5 || !have($item`inflammable leaf`, 11),
-    do: (): void => {
-      visitUrl("campground.php?preaction=leaves");
-      visitUrl("choice.php?pwd&whichchoice=1510&option=1&leaves=11");
-    },
-    combat: new CombatStrategy().killHard(),
-    limit: { tries: 5 },
   },
   {
     name: "God Lobster",

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -214,41 +214,6 @@ const unscaledLeveling: Task[] = [
     limit: { tries: 5 },
   },
   {
-    name: "God Lobster",
-    after: getBuffs,
-    prepare: (): void => {
-      restoreHp(clamp(1000, myMaxhp() / 2, myMaxhp()));
-      unbreakableUmbrella();
-    },
-    completed: () =>
-      get("_godLobsterFights") >= 3 ||
-      !have($familiar`God Lobster`),
-    do: () => visitUrl("main.php?fightgodlobster=1"),
-    combat: new CombatStrategy().killHard(),
-    choices: { 1310: godLobsterChoice() }, // Get xp on last fight
-    outfit: {
-      famequip: $items`God Lobster's Ring, God Lobster's Scepter`,
-      familiar: $familiar`God Lobster`,
-    },
-    post: () => useFamiliar($familiar`Grey Goose`),
-    limit: { tries: 3 },
-    freecombat: true
-  },
-  {
-    name: "Kramco",
-    after: getBuffs,
-    prepare: (): void => {
-      restoreHp(clamp(1000, myMaxhp() / 2, myMaxhp()));
-    },
-    ready: () => getKramcoWandererChance() >= 1.0,
-    completed: () => getKramcoWandererChance() < 1.0 || !have($item`Kramco Sausage-o-Matic™`),
-    do: $location`The Outskirts of Cobb's Knob`,
-    outfit: { offhand: $item`Kramco Sausage-o-Matic™` },
-    combat: new CombatStrategy().killHard(),
-    limit: { tries: 2 },
-    freecombat: true
-  },
-  {
     name: "Snojo",
     after: getBuffs,
     priority: () => Priorities.Start,

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -198,8 +198,7 @@ const unscaledLeveling: Task[] = [
       visitUrl("campground.php?preaction=leaves");
       visitUrl("choice.php?pwd&whichchoice=1510&option=1&leaves=11");
     },
-    combat: new CombatStrategy().macro(Macro.trySkill($skill`Spring Growth Spurt`).attack().repeat()),
-    outfit: {equip: $items`spring shoes`},
+    combat: new CombatStrategy().killHard(),
     limit: { tries: 5 },
   },
   {

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -3,10 +3,8 @@ import {
   cliExecute,
   Item,
   myLevel,
-  myMaxhp,
   myPrimestat,
   myTurncount,
-  restoreHp,
   runChoice,
   use,
   useFamiliar,
@@ -22,10 +20,8 @@ import {
   $skill,
   $stat,
   AprilingBandHelmet,
-  clamp,
   ClosedCircuitPayphone,
   get,
-  getKramcoWandererChance,
   have,
   Macro,
   MayamCalendar,
@@ -43,13 +39,6 @@ const robotSetup = [
   "Robot/Equip Top Initial",
   "Robot/Equip Right Initial",
 ];
-
-function unbreakableUmbrella(): void {
-  if (have($item`unbreakable umbrella`) && get("umbrellaState") !== "broken")
-    cliExecute("umbrella ml");
-}
-
-const godLobsterChoice = () => (have($item`God Lobster's Ring`) ? 2 : 3);
 
 const buffTasks: Task[] = [
   {
@@ -235,6 +224,18 @@ const unscaledLeveling: Task[] = [
     freecombat: true,
   },
   {
+    name: "Neverending Party",
+    after: getBuffs,
+    priority: () => Priorities.Start,
+    completed: () => get("_neverendingPartyFreeTurns") >= 10 || !get("neverendingPartyAlways"),
+    do: $location`The Neverending Party`,
+    choices: { 1322: 2, 1324: 5 },
+    combat: new CombatStrategy().killHard(),
+    outfit: { equip: $items`Space Trip safety headphones` },
+    limit: { tries: 11 },
+    freecombat: true,
+  },
+  {
     name: "Speakeasy",
     after: getBuffs,
     priority: () => Priorities.Start,
@@ -298,22 +299,6 @@ const unscaledLeveling: Task[] = [
     boss: true,
     freecombat: true,
     limit: { tries: 12 },
-  },
-  {
-    name: "Neverending Party",
-    after: getBuffs,
-    priority: () => Priorities.Start,
-    ready: () => get("_shadowAffinityToday") &&
-      !have($effect`Shadow Affinity`) &&
-      (get("_snojoFreeFights") >= 10 || !get("snojoAvailable")) &&
-      get("_loveTunnelUsed"),
-    completed: () => get("_neverendingPartyFreeTurns") >= 10 || !get("neverendingPartyAlways"),
-    do: $location`The Neverending Party`,
-    choices: { 1322: 2, 1324: 5 },
-    combat: new CombatStrategy().killHard(),
-    outfit: { equip: $items`Space Trip safety headphones` },
-    limit: { tries: 11 },
-    freecombat: true,
   },
 ];
 

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -21,12 +21,14 @@ import {
   $monster,
   $skill,
   $stat,
+  AprilingBandHelmet,
   clamp,
   ClosedCircuitPayphone,
   get,
   getKramcoWandererChance,
   have,
   Macro,
+  MayamCalendar,
   set,
 } from "libram";
 import { Priorities } from "../engine/priority";
@@ -112,6 +114,35 @@ const getBuffsPreLOV = buffTasks.map((t) => t.name);
 const getBuffs = [...getBuffsPreLOV, "LOV Tunnel"];
 
 const unscaledLeveling: Task[] = [
+  {
+    name: "Apriling: Boost a Gooso",
+    after: getBuffs,
+    priority: () => Priorities.Free,
+    ready: () => AprilingBandHelmet.have() && AprilingBandHelmet.canJoinSection(),
+    completed: () => $item`Apriling band piccolo`.dailyusesleft === 0,
+    do: (): void => {
+      useFamiliar($familiar`Grey Goose`);
+      if(!have($item`Apriling band piccolo`))
+        AprilingBandHelmet.joinSection($item`Apriling band piccolo`)
+      while($item`Apriling band piccolo`.dailyusesleft > 0)
+        AprilingBandHelmet.play($item`Apriling band piccolo`);
+    },
+    limit: { tries: 1 },
+    freeaction: true,
+  },
+  {
+    name: "Mayam: Boost a Gooso",
+    after: getBuffs,
+    priority: () => Priorities.Free,
+    ready: () => MayamCalendar.have(),
+    completed: () => get("_mayamSymbolsUsed").includes("fur"),
+    do: (): void => {
+      useFamiliar($familiar`Grey Goose`);
+      cliExecute("Mayam fur wood cheese clock")
+    },
+    limit: { tries: 1 },
+    freeaction: true,
+  },
   {
     name: "LOV Tunnel",
     after: getBuffsPreLOV,


### PR DESCRIPTION
Add Kramco (Wander at The Outskirts of Cobb's Knob), God Lobster (free early stats), Burning Leaves (five free fights for gooso) as new fights.

Add Mayam (fur wood cheese clock) and Apriling Piccolo for Gooso XP.

Reorder free fights to put NEP last as it has the best scalers; this will level up somewhat faster as a result.