### PR TITLE
Spend adventures to get chronolith!

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -71,6 +71,10 @@ export const args = Args.create(
         help: "Always flyer the normal way, instead of wishing for a monster",
         default: false,
       }),
+      chronolith: Args.flag({
+        help: "Skip spending turns to get net positive turns from chronolith at the end of the run (turn on to minimize turncount at the expense of aftercore turns)",
+        default: false,
+      }),
     }),
     debug: Args.group("Debug Options", {
       actions: Args.number({

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -294,3 +294,24 @@ export function tryEnsureLucky(): boolean {
   }
   return false;
 }
+
+export function isChronoWorthIt(): boolean {
+  const currentAdventures = myAdventures();
+  let futureAdventures = currentAdventures;
+  let currentEnergy = YouRobot.energy();
+  let numEnergyCollects = 0;
+
+  while (futureAdventures > 0) {
+    futureAdventures -= 1;
+    currentEnergy += Math.round(YouRobot.expectedEnergyNextCollect() * 0.85 ** numEnergyCollects);
+    numEnergyCollects += 1;
+
+    if (currentEnergy >= YouRobot.expectedChronolithCost()) {
+      break;
+    }
+  }
+
+  return (
+    currentEnergy >= YouRobot.expectedChronolithCost() && futureAdventures + 9 > currentAdventures
+  );
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -303,7 +303,7 @@ export function isChronoWorthIt(): boolean {
 
   while (futureAdventures > 0) {
     futureAdventures -= 1;
-    currentEnergy += Math.round(YouRobot.expectedEnergyNextCollect() * 0.85 ** numEnergyCollects);
+    currentEnergy += YouRobot.expectedEnergyNextCollect() * 0.85 ** numEnergyCollects;
     numEnergyCollects += 1;
 
     if (currentEnergy >= YouRobot.expectedChronolithCost()) {

--- a/src/tasks/level13.ts
+++ b/src/tasks/level13.ts
@@ -28,7 +28,7 @@ import {
 } from "libram";
 import { CombatStrategy } from "../engine/combat";
 import { args } from "../args";
-import { atLevel } from "../lib";
+import { atLevel, isChronoWorthIt, YouRobot } from "../lib";
 import { Quest, Task } from "../engine/task";
 import { step } from "grimoire-kolmafia";
 import { customRestoreMp, ensureWithMPSwaps, fillHp } from "../engine/moods";
@@ -605,6 +605,20 @@ export const TowerQuest: Quest = {
         .kill(),
       boss: true,
       limit: { tries: 1 },
+    },
+    {
+      name: "Post-NS Chronolith",
+      after: ["Naughty Sorceress"],
+      completed: () => !isChronoWorthIt() || args.minor.chronolith,
+      do: (): void => {
+        while (isChronoWorthIt()) {
+          while (YouRobot.energy() < YouRobot.expectedChronolithCost()) {
+            YouRobot.doCollectEnergy();
+          }
+          YouRobot.doChronolith();
+        }
+      },
+      limit: {tries: 1},
     },
   ],
 };


### PR DESCRIPTION
You'll note that we value a chronolith at 9 adventures; there's a small bug that allows a chronolith that would take exactly 10 adventures to generate to be run; we solve this by valuing chronolith at 9 adventures (so you always benefit at least 1 adventure).

This was tested in my personal wrapper successfully.