### PR TITLE
survivability improvements

### DIFF
--- a/src/engine/combat.ts
+++ b/src/engine/combat.ts
@@ -1,12 +1,10 @@
 import {
-  expectedDamage,
   familiarWeight,
   haveEquipped,
   Location,
   Monster,
   myBasestat,
   myFamiliar,
-  myHp,
   myPrimestat,
   Stat,
 } from "kolmafia";
@@ -146,8 +144,8 @@ export function dartMacro(hard: boolean, once: boolean): Macro {
 export function killMacro(target?: Monster | Location, hard?: boolean, withSlap = false): Macro {
   const result = new Macro();
 
-  // Level with the Grey Goose if available and can survive at least 2 hits
-  if (myFamiliar() === $familiar`Grey Goose` && familiarWeight($familiar`Grey Goose`) >= 20 && (expectedDamage() * 2) < myHp()) {
+  // Level with the Grey Goose if available
+  if (myFamiliar() === $familiar`Grey Goose` && familiarWeight($familiar`Grey Goose`) >= 20) {
     switch (statToLevel()) {
       case $stat`Muscle`:
         result.trySkill($skill`Convert Matter to Protein`);

--- a/src/engine/combat.ts
+++ b/src/engine/combat.ts
@@ -1,10 +1,12 @@
 import {
+  expectedDamage,
   familiarWeight,
   haveEquipped,
   Location,
   Monster,
   myBasestat,
   myFamiliar,
+  myHp,
   myPrimestat,
   Stat,
 } from "kolmafia";
@@ -144,8 +146,8 @@ export function dartMacro(hard: boolean, once: boolean): Macro {
 export function killMacro(target?: Monster | Location, hard?: boolean, withSlap = false): Macro {
   const result = new Macro();
 
-  // Level with the Grey Goose if available
-  if (myFamiliar() === $familiar`Grey Goose` && familiarWeight($familiar`Grey Goose`) >= 20) {
+  // Level with the Grey Goose if available and can survive at least 2 hits
+  if (myFamiliar() === $familiar`Grey Goose` && familiarWeight($familiar`Grey Goose`) >= 20 && (expectedDamage() * 2) < myHp()) {
     switch (statToLevel()) {
       case $stat`Muscle`:
         result.trySkill($skill`Convert Matter to Protein`);

--- a/src/engine/resources.ts
+++ b/src/engine/resources.ts
@@ -675,7 +675,10 @@ export const forceNCSources: ForceNCSorce[] = [
       have($skill`Torso Awareness`) &&
       have($item`Jurassic Parka`) &&
       get("_spikolodonSpikeUses") + args.minor.saveparka < 5,
-    equip: { equip: $items`Jurassic Parka, designer sweatpants`, modes: { parka: "spikolodon" } },
+      equip: [
+        { equip: $items`Jurassic Parka, designer sweatpants`, modes: { parka: "spikolodon" } },
+        { equip: $items`Jurassic Parka`, modes: { parka: "spikolodon" } }
+        ],
     // Note the externalIf is evaluated only once (at script run)
     do: Macro.trySkill($skill`Summon Love Gnats`)
       .externalIf(!get("lovebugsUnlocked"), Macro.trySkill($skill`Sweat Flood`))

--- a/src/engine/resources.ts
+++ b/src/engine/resources.ts
@@ -675,7 +675,7 @@ export const forceNCSources: ForceNCSorce[] = [
       have($skill`Torso Awareness`) &&
       have($item`Jurassic Parka`) &&
       get("_spikolodonSpikeUses") + args.minor.saveparka < 5,
-    equip: { equip: $items`Jurassic Parka`, modes: { parka: "spikolodon" } },
+    equip: { equip: $items`Jurassic Parka, designer sweatpants`, modes: { parka: "spikolodon" } },
     // Note the externalIf is evaluated only once (at script run)
     do: Macro.trySkill($skill`Summon Love Gnats`)
       .externalIf(!get("lovebugsUnlocked"), Macro.trySkill($skill`Sweat Flood`))


### PR DESCRIPTION
Tested in run. Previously didn't have sweatpants equipped so couldn't use sweat flood. Now has sweat pants equipped and casts flood prior to launch spikes every time

fixes #15 

Also only convert grey goose matter if can survive at least 2 hits